### PR TITLE
Add info on pre-commit hook to README & simple option to add hook locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 # Opt Out <img src='opt_out_logo.png' align="right" height="140" />
 [![CircleCI](https://circleci.com/gh/opt-out-tools/opt-out.svg?style=svg)](https://circleci.com/gh/opt-out-tools/opt-out)
-[![forthebadge](https://forthebadge.com/images/badges/made-with-python.svg)](https://forthebadge.com) [![forthebadge](https://forthebadge.com/images/badges/made-with-javascript.svg)](https://forthebadge.com)  
+[![forthebadge](https://forthebadge.com/images/badges/made-with-python.svg)](https://forthebadge.com) [![forthebadge](https://forthebadge.com/images/badges/made-with-javascript.svg)](https://forthebadge.com)
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
-Opt Out is a browser extension for Firefox that filters online misogyny from an individual’s twitter feed. 
+Opt Out is a browser extension for Firefox that filters online misogyny from an individual’s twitter feed.
 
 The General Data Protection Regulation (GDPR) has changed our lives online on social media platforms. We have the right to be forgotten, to see what is being collected about us and to opt-out if we wish. The current abuse that those who identify as women suffer is not avoidable. We see Opt Out as an extension of the GDPR that also protects the human rights of women and those with intersecting identities online. While steps have been made to protect these people online, not enough has been done. This is a global tragedy affecting the well-being, economical potential and political representation of these people. Let's __Opt Out.__
 
@@ -21,11 +21,62 @@ To test the current prototype:
 3. Set the url to `about:debugging#/runtime/this-firefox` and hit enter
 4. In the `Load Teporary Add-ons` box, open and load `manifest.json` which can be found in the `extensions` folder of this repo you cloned locally
 5. Open Twitter and test!
-6. If you make changes to the code you would like to test, make sure you click "reload" (left of the "remove" button) to apply new changes to script 
+6. If you make changes to the code you would like to test, make sure you click "reload" (left of the "remove" button) to apply new changes to script
 
 ## Project Development
 
 Opt Out is an open source project under active development. Currently, machine learning models are being evaluated for their ability to classify sexual harassment text. If you would like to test the current model (trained on troll data), please see the 'Installation Instructions' below. If you would like to contribute to the project, please see [Contributing](https://github.com/malteserteresa/opt-out/blob/master/contributing.md) first, and then check out the find-out and try-out repos.
+
+
+### Continuous Integration
+
+This project is set up to use [Circle CI](https://circleci.com/) as the CI tool.
+Every Pull request (from branches or forks) and every version of the `master` will automatically start a new build on circle ci.
+This will run the following checks:
+- eslint to ensure coding style guidelines are followed
+- tests TBD
+
+A pull request can only be merged if all checks are successful.
+To avoid any last minute failures, we recommend to use eslint locally before making your commit:
+
+```
+npm run lint
+```
+This will run eslint on all js files and try to fix all problems it finds.
+What can't be fixed automatically will be raised as error.
+
+### Adding a local pre-commit hook
+
+In case you want to be 100% sure that the linter is always running before you commit you can add this as a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+This means it will run the linter before every commit you try to make:
+
+#### The easy way:
+
+If you do not have a pre-commit hook defined yet, there is a script that will copy the file for you.
+Run this command and it will create the pre-commit from a template for you:
+```
+npm run git:initHook
+```
+
+If you already have a pre-commit hook defined but don't care about overwriting it, you can use the same command with the `-f` flag.
+This will copy the template even if the file exists already.
+```
+npm run git:initHook -f
+```
+
+
+#### The slightly harder way
+
+1. Open the file `.git/hooks/pre-commit`
+2. If the file does not exist, create it.
+2. Add the following to the file and save it:
+```
+npm run lint
+RESULT=$?
+[ $RESULT -ne 0 ] && exit 1
+exit 0
+```
+
 
 ## Funding
 If you would like to fund the project or make a donation, please email [Opt Out](mailto:opt-out-tool@gmail.com).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint --fix ."
+    "lint": "eslint --fix .",
+    "git:initHook": "scripts/addPreCommitHook.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/addPreCommitHook.sh
+++ b/scripts/addPreCommitHook.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+PRE_COMMIT_PATH=.git/hooks/pre-commit
+FORCE=0
+
+while getopts ":f" opt; do
+  case $opt in
+    f)
+      echo "Command invoked with -f flag, overwriting existing hook..." >&2
+      FORCE=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
+if [ $FORCE -eq 0 -a -e $PRE_COMMIT_PATH ]; then
+  echo "Failed: $PRE_COMMIT_PATH exists"
+  exit 1
+fi
+
+echo "Copying template pre-commit hook to $PRE_COMMIT_PATH..."
+cp scripts/pre-commit.template $PRE_COMMIT_PATH
+chmod +x $PRE_COMMIT_PATH
+
+if [ $? -eq 0 ]; then
+    echo "Success!"
+else
+    echo "Failed: pre-commit template was not copied to $PRE_COMMIT_PATH"
+fi
+
+
+

--- a/scripts/pre-commit.template
+++ b/scripts/pre-commit.template
@@ -1,0 +1,6 @@
+npm run lint
+RESULT=$?
+[ $RESULT -ne 0 ] && exit 1
+exit 0
+
+# test 2


### PR DESCRIPTION
As discussed in #43 , the pre-commit can only be enforced locally with additional dependencies.

I now added a bit to the README on the linter and CI and also on how to set up the local pre-commit hook.
To make this super easy, I also added a template and a shell script to copy the template to the .git/hooks folder.

Please have a look and let me know if you think this setup is "contributor friendly" and if the README contains enough info on this setup.

