### PR TITLE
Fixes for broken functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,40 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
 node_modules/
+
+# profiling files
+chrome-profiler-events.json
+speed-measure-plugin.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db
+

--- a/extension/content/opt-out-ext.js
+++ b/extension/content/opt-out-ext.js
@@ -1,5 +1,17 @@
 let selector;
-let option = 'tw';
+let option = 'text_crossed';
+let slider = '1';
+
+function updateOption(result) {
+  option = result.optOut.selector;
+  slider = result.optOut.slider;
+}
+
+function onError(error) {
+  console.log(`Error: ${error}`);
+}
+browser.storage.sync.get('optOut').then(updateOption, onError);
+
 
 const root = document.getElementById('doc') || document.getElementById('react-root');
 
@@ -14,12 +26,12 @@ if (document.querySelector('body').classList.contains('logged-out')) {
 /*
 Depending on `option` sets classes to tweet nodes
  */
-const styleTweet = function (element, selectedOption) {
-  if (selectedOption.includes('tw')) element.classList.add('opt-out-tw');
+const styleTweet = function (element, selectedOption, sliderValue) {
+  if ((selectedOption === 'text_white') && (sliderValue === '1')) element.classList.add('opt-out-tw');
   else element.classList.remove('opt-out-tw');
-  if (selectedOption.includes('tc')) element.classList.add('opt-out-tc');
+  if ((selectedOption === 'text_crossed') && (sliderValue === '1')) element.classList.add('opt-out-tc');
   else element.classList.remove('opt-out-tc');
-  if (selectedOption.includes('tr')) element.classList.add('opt-out-trem');
+  if ((selectedOption === 'text_removed') && (sliderValue === '1')) element.classList.add('opt-out-trem');
   else element.classList.remove('opt-out-trem');
 };
 
@@ -48,7 +60,7 @@ const checkText = function (node) {
         const tweetText = node.querySelector(
           `${selector} > div ~ div > div ~ div`,
         );
-        styleTweet(tweetText, option);
+        styleTweet(tweetText, option, slider);
       } else {
         node.classList.add('processed-false');
       }
@@ -68,14 +80,15 @@ const checkText = function (node) {
  * Predefines action and changes it depending on user action
  */
 browser.runtime.onMessage.addListener((message) => {
-  if (option !== message.command) {
-    option = message.command;
+  if ((option !== message.selector) || (slider !== message.slider)) {
+    option = message.selector;
+    slider = message.slider;
     const posts = document.querySelectorAll('.processed-true');
     posts.forEach((post) => {
       const tweetText = post.querySelector(
         `${selector} > div ~ div > div ~ div`,
       ); // selecting text inside tweet
-      styleTweet(tweetText, option);
+      styleTweet(tweetText, option, slider);
     });
   }
 });
@@ -96,5 +109,6 @@ const checkTweetList = function (mutationsList) {
     }
   });
 };
+
 const checkTweetListObserver = new MutationObserver(checkTweetList);
 checkTweetListObserver.observe(root, { childList: true, subtree: true });

--- a/extension/popup/set_view_mod.html
+++ b/extension/popup/set_view_mod.html
@@ -16,20 +16,20 @@
         </div>
         <div>
             <label for="slider">
-                <input type="range" id="slider" name="slider" min="0" max="1" value="1" list="tickmarks">
+                <input type="range" id="slider" name="slider" min="0" max="1" value="1">
             </label>
         </div>
         <h2>How should it be hidden?</h2>
         <label for="text_crossed">
-            <input type="radio" id="text_crossed" name="text_options">
+            <input type="radio" id="text_crossed" name="text_options" value="text_crossed" checked>
             <span>Crossed through</span>
         </label>
         <label for="text_white">
-            <input type="radio" id="text_white" name="text_options"checked>
+            <input type="radio" id="text_white" name="text_options" value="text_white">
             <span>White text</span>
         </label>
         <label for="text_removed">
-            <input type="radio" id="text_removed" name="text_options">
+            <input type="radio" id="text_removed" name="text_options" value="text_removed">
             <span>Completely removed</span>
         </label>
         <p class="link">
@@ -44,7 +44,7 @@
 
     <script src="set_view_mod.js"></script>
 
-    
+
 </body>
 
 </html>


### PR DESCRIPTION
-updated .gitignore file
-restored functionality for switching options by restoring restoreOptions function to set_view_mode.js
-restored style subselector in restoreOptions in order to save options to sync storage
-set values for radio buttons in html popup file
-modified listenForClick to work with radio buttons instead of checkboxes
-changed setting sync.storage and browser.message to object from string
-updated option values in massage to match option selector names
-added default option text-crossed and set update from sync.storage onLoad
-added slider functionality to storage.sync
-merged changing of styles to range knob