### PR TITLE
Fixing version and disabling minimization

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Opt Out",
-  "version": "1.0",
+  "version": "0.01",
 
   "description": "Blocks offensive and inappropriate tweets.",
   "permissions": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,9 @@ module.exports = {
   module: {
     rules: []
   },
+  optimization: {
+    minimize: false
+  },
   // Copies static assets to correct places
   plugins: [
     new CopyPlugin([


### PR DESCRIPTION
Since we aren't officially 1.0 and firefox Addons are recommended to be unminimized.

See: https://extensionworkshop.com/documentation/publish/submitting-an-add-on/
ref: https://github.com/opt-out-tools/opt-out/issues/99