### PR TITLE
Slider prepared for floats

### DIFF
--- a/src/content/functions/styleTweet.js
+++ b/src/content/functions/styleTweet.js
@@ -10,7 +10,7 @@ export default function (element, popupPrefs) {
     // Tweet is predicted to be misogynist
     tweetPredictionValue !== 0 &&
     // Tweets prediction value is enough to modify
-    tweetPredictionValue >= modifyTweetThreshold
+    tweetPredictionValue > modifyTweetThreshold
   ) {    
     switch (popupPrefs.optionVal) {
       case 'text_white':

--- a/src/content/functions/styleTweet.js
+++ b/src/content/functions/styleTweet.js
@@ -9,8 +9,6 @@ export default function (element, popupPrefs) {
   if (
     // Tweet is predicted to be misogynist
     tweetPredictionValue !== 0 &&
-    // Option to modify tweet is turned on
-    modifyTweetThreshold !== 0 &&
     // Tweets prediction value is enough to modify
     tweetPredictionValue > modifyTweetThreshold
   ) {

--- a/src/content/functions/styleTweet.js
+++ b/src/content/functions/styleTweet.js
@@ -9,9 +9,11 @@ export default function (element, popupPrefs) {
   if (
     // Tweet is predicted to be misogynist
     tweetPredictionValue !== 0 &&
+    // Option to modify tweet is turned on
+    modifyTweetThreshold !== 0 &&
     // Tweets prediction value is enough to modify
     tweetPredictionValue > modifyTweetThreshold
-  ) {    
+  ) {
     switch (popupPrefs.optionVal) {
       case 'text_white':
         element.classList.add('opt-out-tw');

--- a/src/content/functions/styleTweet.spec.js
+++ b/src/content/functions/styleTweet.spec.js
@@ -8,7 +8,7 @@ describe('styleTweet.js', () => {
     beforeEach(() => {
       popupPrefs = {
         // Show no tweets predicted misogynist
-        sliderVal: 0.1,
+        sliderVal: 0,
         optionVal: 'text_removed',
       };
 

--- a/src/content/functions/styleTweet.spec.js
+++ b/src/content/functions/styleTweet.spec.js
@@ -8,7 +8,7 @@ describe('styleTweet.js', () => {
     beforeEach(() => {
       popupPrefs = {
         // Show no tweets predicted misogynist
-        sliderVal: 0,
+        sliderVal: 0.1,
         optionVal: 'text_removed',
       };
 

--- a/src/content/opt-out-ext.js
+++ b/src/content/opt-out-ext.js
@@ -23,7 +23,7 @@ const tweetSelector = (document.querySelector('body').classList.contains('logged
  */
 let popupPrefs = {
   optionVal: 'text_crossed',
-  sliderVal: '1'
+  sliderVal: '0'
 };
 
 /**

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -16,7 +16,7 @@
         </div>
         <div>
             <label for="slider">
-                <input type="range" id="slider" name="slider" min="0" max="1" value="1" step="1">
+                <input type="range" id="slider" name="slider" min="0" max="1" value="0" step="1">
             </label>
 
         </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -11,8 +11,8 @@
     <div id="popup-content">
         <h2>How much misogyny do you want to remove?</h2>
         <div id="rangeText">
-            <p>None</p>
             <p>All of it!</p>
+            <p>None</p>
         </div>
         <div>
             <label for="slider">


### PR DESCRIPTION
https://github.com/opt-out-tools/opt-out/issues/93

Changes:
* `styleTweet` now able to handle floats correctly. Updates test for that.
* Changes the order of slider to make more sense

I have updated the code in styleTweet. This is because the slider was backwards. I think this makes more sense, while we still have the slider. 
* TODO: The logic in this dictates UX. We should have the expected behaviour documented somewhere
* TODO:  The code for checking if a tweet should be styled should not be in the style tweet function. It should probably go in a function just for checking the confidence against the threshold.
* We should consider making the slider text something like
Hide all       Hide most        Hide some        Hide none
