### PR TITLE
Test checkText

### DIFF
--- a/.web-ext-config.js
+++ b/.web-ext-config.js
@@ -1,9 +1,10 @@
 module.exports = {
-	sourceDir: 'dist',
-	run: {
-		keepProfileChanges: true,
-	},
-	build: {
-		overwriteDest: true,
-	}
-}
+  sourceDir: 'dist',
+  run: {
+    keepProfileChanges: true,
+    firefox: '/opt/firefox/firefox-bin',
+  },
+  build: {
+    overwriteDest: true,
+  },
+};

--- a/.web-ext-config.js
+++ b/.web-ext-config.js
@@ -2,7 +2,6 @@ module.exports = {
   sourceDir: 'dist',
   run: {
     keepProfileChanges: true,
-    firefox: '/opt/firefox/firefox-bin',
   },
   build: {
     overwriteDest: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3434,6 +3434,24 @@
         "babel-plugin-jest-hoist": "^25.2.1"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -7301,6 +7319,42 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-mock": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.4.0.tgz",
+      "integrity": "sha512-tqnFmcjYheW5Z9zOPRVY+ZXjB/QWCYtPiOrYGEsPgKfpGHco97eaaj7Rv9MjK7PVWG4rWfv6t2IgQAzDQizBZA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -7813,6 +7867,12 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "global-dirs": {
       "version": "2.0.1",
@@ -8767,6 +8827,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
@@ -11087,6 +11153,12 @@
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
@@ -12239,6 +12311,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
       "dev": true
     },
     "path-type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11655,6 +11655,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "fetch-mock": "^9.4.0",
     "geckodriver": "^1.19.1",
     "jest": "^25.2.3",
     "jest-webextension-mock": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "geckodriver": "^1.19.1",
     "jest": "^25.2.3",
     "jest-webextension-mock": "^3.5.0",
+    "node-fetch": "^2.6.0",
     "selenium-webdriver": "^3.6.0",
     "web-ext": "^4.1.0",
     "webpack": "^4.42.1",
@@ -60,5 +61,6 @@
         ]
       }
     }
-  }
+  },
+  "dependencies": {}
 }

--- a/src/content/opt-out-ext.js
+++ b/src/content/opt-out-ext.js
@@ -40,7 +40,6 @@ const checkTweetList = (mutationsList) => {
   });
 };
 
-
 /**
  * Setting preferences color to match twitter body color
  */

--- a/src/content/tests/checkText.test.js
+++ b/src/content/tests/checkText.test.js
@@ -59,7 +59,7 @@ describe('checkText.js', () => {
     });
   });
 
-  test('check proccessing state applied during api resolution', async () => {
+  test('check proccessing state applied during api resolution and removed after', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, 400);
 
     // Check text function
@@ -75,7 +75,7 @@ describe('checkText.js', () => {
     expect(element.classList.contains('processing')).toEqual(false);
   });
 
-  test('on error response, throw error and apply correct state to tweet', async () => {
+  test('on error response, log error and apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 400,
       body: { texts: ['This is bad, man'] }

--- a/src/content/tests/checkText.test.js
+++ b/src/content/tests/checkText.test.js
@@ -20,7 +20,7 @@ describe('checkText.js', () => {
 
     popupPrefs = {
       sliderVal: 1,
-      optionVal: 'text_removed'
+      optionVal: 'text_removed',
     };
 
     // Create dom element
@@ -46,7 +46,10 @@ describe('checkText.js', () => {
   });
 
   test('check that the fetch API fired with correct body', async () => {
-    fetchMock.postOnce(OPT_OUT_API_URL, 200);
+    fetchMock.postOnce(OPT_OUT_API_URL, {
+      status: 200,
+      body: {},
+    });
 
     checkText(element, SELECTOR_ONLINE_TWEET, popupPrefs);
 
@@ -55,12 +58,15 @@ describe('checkText.js', () => {
     expect(fetchMock.calls().length).toBe(1);
     // Includes correct request body
     expect(JSON.parse(fetchMock.lastOptions(OPT_OUT_API_URL).body)).toEqual({
-      texts: ['I\'m here and I\'m queer']
+      texts: ["I'm here and I'm queer"],
     });
   });
 
   test('check proccessing state applied during api resolution and removed after', async () => {
-    fetchMock.postOnce(OPT_OUT_API_URL, 400);
+    fetchMock.postOnce(OPT_OUT_API_URL, {
+      status: 200,
+      body: { texts: ['Error!'] },
+    });
 
     // Check text function
     checkText(element, SELECTOR_ONLINE_TWEET, popupPrefs);
@@ -78,7 +84,7 @@ describe('checkText.js', () => {
   test('on error response, log error and apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 400,
-      body: { texts: ['This is bad, man'] }
+      body: { texts: ['This is bad, man'] },
     });
 
     // Check text function
@@ -92,7 +98,7 @@ describe('checkText.js', () => {
   test('on success response with no prediction, apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 200,
-      body: { predictions: [] }
+      body: { predictions: [] },
     });
 
     // Check text function
@@ -107,7 +113,7 @@ describe('checkText.js', () => {
   test('on success response with true prediction, apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 200,
-      body: { predictions: [true] }
+      body: { predictions: [true] },
     });
 
     // Check text function

--- a/src/content/tests/checkText.test.js
+++ b/src/content/tests/checkText.test.js
@@ -1,5 +1,50 @@
-describe('Test', () => {
-  test('testing jest', () => {
-    expect(true).toEqual(true);
+import checkText from '../functions/checkText';
+import {
+  SELECTOR_ONLINE_TWEET,
+  OPT_OUT_API_URL
+} from '../constants';
+
+const fetchMock = require("fetch-mock");
+fetchMock.mock(OPT_OUT_API_URL, 200);
+
+describe('checkText.js', () => {
+  let popupPrefs;
+  let element;
+
+  beforeEach(() => {
+
+    popupPrefs = {
+      // Show no tweets predicted misogynist
+      sliderVal: 0.1,
+      optionVal: 'text_removed',
+    };
+    // Create dom element
+    document.body.innerHTML = `
+      <div id='testElement'>
+        <div class="tweet" data-testid="tweet">
+            <div>
+              <div></div> 
+              <div></div>
+            </div>
+            <div>
+              <div></div>
+              <div id="tweetText">I'm here and I'm queer</div>
+            </div>
+        </div>
+      </div>
+    `;
+    element = document.getElementById('testElement');
+    tweetText = document.getElementById('tweetText');
+    tweetText.innerText = tweetText.innerHTML;
+
+  });
+
+  test('check that the fetch API fired', () => {
+    checkText(element, SELECTOR_ONLINE_TWEET, popupPrefs);
+    expect(fetchMock.called(OPT_OUT_API_URL)).toBe(true);
+    expect(fetchMock.calls().length).toBe(1);
+    expect(JSON.parse(fetchMock.lastOptions(OPT_OUT_API_URL)['body'])).toEqual({texts: ["I'm here and I'm queer"]});
   });
 });
+
+

--- a/src/content/tests/checkText.test.js
+++ b/src/content/tests/checkText.test.js
@@ -20,7 +20,7 @@ describe('checkText.js', () => {
 
     popupPrefs = {
       sliderVal: 1,
-      optionVal: 'text_removed',
+      optionVal: 'text_removed'
     };
 
     // Create dom element
@@ -48,7 +48,7 @@ describe('checkText.js', () => {
   test('check that the fetch API fired with correct body', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 200,
-      body: {},
+      body: {}
     });
 
     checkText(element, SELECTOR_ONLINE_TWEET, popupPrefs);
@@ -58,14 +58,14 @@ describe('checkText.js', () => {
     expect(fetchMock.calls().length).toBe(1);
     // Includes correct request body
     expect(JSON.parse(fetchMock.lastOptions(OPT_OUT_API_URL).body)).toEqual({
-      texts: ["I'm here and I'm queer"],
+      texts: ['I\'m here and I\'m queer']
     });
   });
 
   test('check proccessing state applied during api resolution and removed after', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 200,
-      body: { texts: ['Error!'] },
+      body: { texts: ['Error!'] }
     });
 
     // Check text function
@@ -84,7 +84,7 @@ describe('checkText.js', () => {
   test('on error response, log error and apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 400,
-      body: { texts: ['This is bad, man'] },
+      body: { texts: ['This is bad, man'] }
     });
 
     // Check text function
@@ -98,7 +98,7 @@ describe('checkText.js', () => {
   test('on success response with no prediction, apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 200,
-      body: { predictions: [] },
+      body: { predictions: [] }
     });
 
     // Check text function
@@ -113,7 +113,7 @@ describe('checkText.js', () => {
   test('on success response with true prediction, apply correct state to tweet', async () => {
     fetchMock.postOnce(OPT_OUT_API_URL, {
       status: 200,
-      body: { predictions: [true] },
+      body: { predictions: [true] }
     });
 
     // Check text function

--- a/src/content/tests/styleTweet.test.js
+++ b/src/content/tests/styleTweet.test.js
@@ -9,7 +9,7 @@ describe('styleTweet.js', () => {
       popupPrefs = {
         // Show no tweets predicted misogynist
         sliderVal: 0.1,
-        optionVal: 'text_removed',
+        optionVal: 'text_removed'
       };
 
       // Create dom element
@@ -39,7 +39,7 @@ describe('styleTweet.js', () => {
       styleTweet(element, {
         // Show all tweets predicted misogynist
         sliderVal: 1,
-        optionVal: 'text_removed',
+        optionVal: 'text_removed'
       });
       expect(element.classList.contains('opt-out-trem')).toBe(false);
     });
@@ -56,7 +56,7 @@ describe('styleTweet.js', () => {
       styleTweet(element, {
         // Show all tweets predicted misogynist
         sliderVal: 1,
-        optionVal: 'text_removed',
+        optionVal: 'text_removed'
       });
       expect(element.classList.contains('opt-out-trem')).toBe(false);
     });


### PR DESCRIPTION
One of the requirements of: https://github.com/opt-out-tools/opt-out/issues/105

Tests the following behaviours in `checkText`:
* Getting the text out of the tweet node
* Sending the text in a fetch request to the backend
* Putting a proccessing state on the tweet node while waiting for the response to resolve
* Putting `processed-false` on to the tweet text node if not misogynist or error in fetch
* Putting `data-prediction=<number 0 | 1>` to tweet text node if misogynist

**TODO**: Some of these actions should possibly be moved to their own functions.
 