### PR TITLE
updateSliderKnob runs at correct time

### DIFF
--- a/.web-ext-config.js
+++ b/.web-ext-config.js
@@ -1,9 +1,9 @@
 module.exports = {
-	sourceDir: 'dist',
-	run: {
-		keepProfileChanges: true,
-	},
-	build: {
-		overwriteDest: true,
-	}
-}
+  sourceDir: 'dist',
+  run: {
+    keepProfileChanges: true,
+  },
+  build: {
+    overwriteDest: true,
+  },
+};

--- a/src/popup/functions/updateOptions.js
+++ b/src/popup/functions/updateOptions.js
@@ -5,8 +5,21 @@ import updateSliderKnob from './updateSliderKnob.js';
  * @param result {object}
  */
 export default function (result) {
-  document.querySelector(`#${result.optOut.selector}`).checked = true;
   const slider = document.querySelector('#slider');
-  slider.value = result.optOut.slider;
-  updateSliderKnob(slider);
+  // If no saved settings in local storage
+  if (
+    Object.keys(result).length === 0 ||
+    result.optOut == null ||
+    result.optOut.slider == null ||
+    result.optOut.selector == null
+  ) {
+    // Set slider class for display
+    updateSliderKnob(slider);
+  } else {
+    // If there are saved settings
+    document.querySelector(`#${result.optOut.selector}`).checked = true;
+    // Set the settings on the slider
+    slider.value = result.optOut.slider;
+    updateSliderKnob(slider);
+  }
 }

--- a/src/popup/functions/updateOptions.js
+++ b/src/popup/functions/updateOptions.js
@@ -16,9 +16,7 @@ export default function (result) {
     document.querySelector(`#${result.optOut.selector}`).checked = true;
     // Set the settings on the slider
     slider.value = result.optOut.slider;
-    updateSliderKnob(slider);
-  } else {
-    // No saved settings
-    updateSliderKnob(slider);
   }
+  // Update style on slider input
+  updateSliderKnob(slider);
 }

--- a/src/popup/functions/updateOptions.js
+++ b/src/popup/functions/updateOptions.js
@@ -10,8 +10,7 @@ export default function (result) {
   if (
     Object.keys(result).length === 0 ||
     result.optOut == null ||
-    result.optOut.slider == null ||
-    result.optOut.selector == null
+    (result.optOut.slider == null && result.optOut.selector == null)
   ) {
     // Set slider class for display
     updateSliderKnob(slider);

--- a/src/popup/functions/updateOptions.js
+++ b/src/popup/functions/updateOptions.js
@@ -6,19 +6,19 @@ import updateSliderKnob from './updateSliderKnob.js';
  */
 export default function (result) {
   const slider = document.querySelector('#slider');
-  // If no saved settings in local storage
   if (
-    Object.keys(result).length === 0 ||
-    result.optOut == null ||
-    (result.optOut.slider == null && result.optOut.selector == null)
+    // There are saved settings
+    result &&
+    result.optOut &&
+    result.optOut.slider &&
+    result.optOut.selector
   ) {
-    // Set slider class for display
-    updateSliderKnob(slider);
-  } else {
-    // If there are saved settings
     document.querySelector(`#${result.optOut.selector}`).checked = true;
     // Set the settings on the slider
     slider.value = result.optOut.slider;
+    updateSliderKnob(slider);
+  } else {
+    // No saved settings
     updateSliderKnob(slider);
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/opt-out-tools/opt-out/issues/117

Handles case where slider has no saved settings, so that it updates the style of the slider knob correctly.