### PR TITLE
updated CSS so that images are now shown on text-white and text-cro…

### DIFF
--- a/src/content/opt-out.css
+++ b/src/content/opt-out.css
@@ -14,8 +14,16 @@
     color: var(--color, white);
 }
 
+.opt-out-tw div{
+    background-image: none !important;
+}
+
 .opt-out-tc {
     text-decoration: line-through;
+}
+
+.opt-out-tc div{
+    background-image: none !important;
 }
 
 .opt-out-trem {


### PR DESCRIPTION
Added CSS rule which blocks images for showing on text-white and text-crossed modes.
Relates to issue #77. I Still recommend making images crossed for text-crossed mode and leaves it as in this push for text-white mode.